### PR TITLE
prevent collect2.exe errors from bash.bat

### DIFF
--- a/files/default/bash.bat
+++ b/files/default/bash.bat
@@ -11,3 +11,4 @@ rem which uses this environment variable to change directories.
 set CHERE_INVOKING=1
 
 %~dp0..\usr\bin\bash.exe -l %*
+rem >> %~dp0logoutput.txt


### PR DESCRIPTION
I shamefully have no idea why this fixes the chef-dk zlib build and why the chef builders seem fine without it.

This was removed in the previous release and I'm guessing it was seen as trivial cruft.
