### PR TITLE
Enable unified mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the mingw cookbook.
 
 ## Unreleased
 
+- Enabled unified mode
+
 ## 2.1.3 - *2021-08-31*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/resources/get.rb
+++ b/resources/get.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+# enable unified mode
+unified_mode true
+
 # Installs the core msys utilities needed for mingw/git/any other posix
 # based toolchain at a desired location using mingw-get.exe.
 

--- a/resources/msys2_package.rb
+++ b/resources/msys2_package.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+# enable unified mode
+unified_mode true
+
 # Installs msys2 base system and installs/upgrades packages within in.
 #
 # Where's the version flag? Where's idempotence you say? Well f*** you

--- a/resources/tdm_gcc.rb
+++ b/resources/tdm_gcc.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+# enable unified mode
+unified_mode true
+
 # Installs a gcc based C/C++ compiler and runtime from TDM GCC.
 
 property :flavor, Symbol, is: [:sjlj_32, :seh_sjlj_64], default: :seh_sjlj_64


### PR DESCRIPTION
# Description

Enabled unified mode, since it'll be the default mode on Chef Infra Client 18.x

## Issues Resolved

N/A

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
